### PR TITLE
Update to include torch 1.13 release change

### DIFF
--- a/example.py
+++ b/example.py
@@ -12,11 +12,12 @@ dist.init_process_group("dummy", rank=0, world_size=1)
 
 x = torch.ones(6)
 dist.all_reduce(x)
-y = x.cuda()
-dist.all_reduce(y)
-
 print(f"cpu allreduce: {x}")
-print(f"cuda allreduce: {y}")
+
+if torch.cuda.is_available():
+    y = x.cuda()
+    dist.all_reduce(y)
+    print(f"cuda allreduce: {y}")
 
 try:
     dist.broadcast(x, 0)

--- a/include/dummy.hpp
+++ b/include/dummy.hpp
@@ -2,10 +2,11 @@
 
 #include <torch/python.h>
 
-#include <c10d/ProcessGroup.hpp>
-#include <c10d/Store.hpp>
-#include <c10d/Types.hpp>
-#include <c10d/Utils.hpp>
+#include <torch/csrc/distributed/c10d/ProcessGroup.hpp>
+#include <torch/csrc/distributed/c10d/Work.hpp>
+#include <torch/csrc/distributed/c10d/Store.hpp>
+#include <torch/csrc/distributed/c10d/Types.hpp>
+#include <torch/csrc/distributed/c10d/Utils.hpp>
 
 #include <pybind11/chrono.h>
 
@@ -14,94 +15,76 @@ namespace c10d {
 class ProcessGroupDummy : public ProcessGroup {
  public:
 
-  class WorkDummy : public ProcessGroup::Work {
-   public:
-    WorkDummy(
-        OpType opType,
-        c10::intrusive_ptr<c10::ivalue::Future> future) // future of the output
-        : ProcessGroup::Work(
-              -1, // rank, only used by recvAnySource, irrelevant in this demo
-              opType),
-          future_(std::move(future)) {}
-    bool isCompleted() override;
-    bool isSuccess() const override;
-    bool wait(std::chrono::milliseconds timeout = kUnsetTimeout) override;
-    virtual c10::intrusive_ptr<c10::ivalue::Future> getFuture() override;
-
-   private:
-    c10::intrusive_ptr<c10::ivalue::Future> future_;
-  };
-
   ProcessGroupDummy(int rank, int size);
 
-  c10::intrusive_ptr<ProcessGroup::Work> broadcast(
+  c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
+  c10::intrusive_ptr<Work> allreduce_coalesced(
       std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> reduce(
+  c10::intrusive_ptr<Work> reduce(
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allgather(
+  c10::intrusive_ptr<Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
+  c10::intrusive_ptr<Work> _allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> barrier(
+  c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> gather(
+  c10::intrusive_ptr<Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> scatter(
+  c10::intrusive_ptr<Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
+  c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
+  c10::intrusive_ptr<Work> alltoall_base(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,
       std::vector<int64_t>& inputSplitSizes,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> alltoall(
+  c10::intrusive_ptr<Work> alltoall(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> send(
+  c10::intrusive_ptr<Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> recv(
+  c10::intrusive_ptr<Work> recv(
       std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
+  c10::intrusive_ptr<Work> recvAnysource(
       std::vector<at::Tensor>& tensors,
       int tag) override;
 
@@ -117,6 +100,25 @@ class ProcessGroupDummy : public ProcessGroup {
         module.attr("Backend").attr("register_backend");
     register_backend("dummy", py::cpp_function(createProcessGroupDummy));
   }
+};
+
+class WorkDummy : public Work {
+    friend class ProcessGroupDummy;
+public:
+    WorkDummy(
+        OpType opType,
+        c10::intrusive_ptr<c10::ivalue::Future> future) // future of the output
+        : Work(
+              -1, // rank, only used by recvAnySource, irrelevant in this demo
+              opType),
+          future_(std::move(future)) {}
+    bool isCompleted() override;
+    bool isSuccess() const override;
+    bool wait(std::chrono::milliseconds timeout = kUnsetTimeout) override;
+    virtual c10::intrusive_ptr<c10::ivalue::Future> getFuture() override;
+
+private:
+    c10::intrusive_ptr<c10::ivalue::Future> future_;
 };
 
 } // namespace c10d

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -3,19 +3,19 @@
 namespace c10d {
 
 
-bool ProcessGroupDummy::WorkDummy::isCompleted() {
+bool WorkDummy::isCompleted() {
   return true;
 }
 
-bool ProcessGroupDummy::WorkDummy::isSuccess() const {
+bool WorkDummy::isSuccess() const {
   return true;
 }
 
-bool ProcessGroupDummy::WorkDummy::wait(std::chrono::milliseconds /* unused */) {
+bool WorkDummy::wait(std::chrono::milliseconds /* unused */) {
   return true;
 }
 
-c10::intrusive_ptr<c10::ivalue::Future> ProcessGroupDummy::WorkDummy::getFuture() {
+c10::intrusive_ptr<c10::ivalue::Future> WorkDummy::getFuture() {
   return future_;
 }
 
@@ -26,7 +26,7 @@ ProcessGroupDummy::ProcessGroupDummy(int rank, int size)
 
 // This is a dummy allgather that sets all output tensors to zero
 // Modify the implementation to conduct real communication asynchronously
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::allgather(
+c10::intrusive_ptr<Work> ProcessGroupDummy::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& /* unused */) {
@@ -42,7 +42,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::allgather(
   return c10::make_intrusive<WorkDummy>(OpType::ALLGATHER, std::move(future));
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupDummy::_allgather_base(
     at::Tensor& /* unused */,
     at::Tensor& /* unused */,
     const AllgatherOptions& /* unused */) {
@@ -51,7 +51,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::_allgather_base(
 
 // This is a dummy allreduce that sets all output tensors to zero
 // Modify the implementation to conduct real communication asynchronously
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::allreduce(
+c10::intrusive_ptr<Work> ProcessGroupDummy::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts) {
   for (auto& tensor : tensors) {
@@ -64,20 +64,20 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::allreduce(
   return c10::make_intrusive<WorkDummy>(OpType::ALLGATHER, std::move(future));
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::allreduce_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupDummy::allreduce_coalesced(
     std::vector<at::Tensor>& /* unused */,
     const AllreduceCoalescedOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::alltoall(
+c10::intrusive_ptr<Work> ProcessGroupDummy::alltoall(
     std::vector<at::Tensor>& /* unused */,
     std::vector<at::Tensor>& /* unused */,
     const AllToAllOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupDummy::alltoall_base(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -86,59 +86,59 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::alltoall_base(
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::barrier(
+c10::intrusive_ptr<Work> ProcessGroupDummy::barrier(
     const BarrierOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::broadcast(
+c10::intrusive_ptr<Work> ProcessGroupDummy::broadcast(
     std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::gather(
+c10::intrusive_ptr<Work> ProcessGroupDummy::gather(
     std::vector<std::vector<at::Tensor>>& /* unused */,
     std::vector<at::Tensor>& /* unused */,
     const GatherOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::reduce(
+c10::intrusive_ptr<Work> ProcessGroupDummy::reduce(
     std::vector<at::Tensor>& /* unused */,
     const ReduceOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::reduce_scatter(
+c10::intrusive_ptr<Work> ProcessGroupDummy::reduce_scatter(
     std::vector<at::Tensor>& /* unused */,
     std::vector<std::vector<at::Tensor>>& /* unused */,
     const ReduceScatterOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::scatter(
+c10::intrusive_ptr<Work> ProcessGroupDummy::scatter(
     std::vector<at::Tensor>& /* unused */,
     std::vector<std::vector<at::Tensor>>& /* unused */,
     const ScatterOptions& /* unused */) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::send(
+c10::intrusive_ptr<Work> ProcessGroupDummy::send(
     std::vector<at::Tensor>& tensors,
     int dstRank,
     int tag) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::recv(
+c10::intrusive_ptr<Work> ProcessGroupDummy::recv(
     std::vector<at::Tensor>& tensors,
     int srcRank,
     int tag) {
   throw std::runtime_error("not supported");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupDummy::recvAnysource(
+c10::intrusive_ptr<Work> ProcessGroupDummy::recvAnysource(
     std::vector<at::Tensor>& tensors,
     int tag) {
   throw std::runtime_error("not supported");


### PR DESCRIPTION
It covers two changes in c10d introduced in torch 1.13:
- Extract ProcessGroup::Work into a separate class refer to https://github.com/pytorch/pytorch/pull/83680
- Install c10d headers with absolute path refer to https://github.com/pytorch/pytorch/pull/86933

How to test:
1. Download a RC wheel from https://github.com/pytorch/pytorch/suites/8933836327/artifacts/410128673 including both changes
2. `pip3 install --pre torch --force-reinstall torch-1.13.0.dev20221024+cpu-cp39-cp39-linux_x86_64.whl`
3. `python3 setup.py install`
4. `python3 example.py`